### PR TITLE
MSP-101: Fixed issues preventing nesting of templates

### DIFF
--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -499,7 +499,7 @@ Resources:
           PrivateSubnet2ID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
           SecurityGroup: !Ref NodeSecurityGroup
 
-    BastionAndEksClusterStack:
+    EKSStack:
       Type: AWS::CloudFormation::Stack
       DependsOn:
         - VPCStack
@@ -583,7 +583,7 @@ Resources:
       Type: AWS::CloudFormation::Stack
       DependsOn:
         - EFSStack
-        - BastionAndEksClusterStack
+        - EKSStack
         - RDSStack
         - S3Stack
       Properties:
@@ -599,8 +599,8 @@ Resources:
           EFSName: !GetAtt EFSStack.Outputs.EFSName
           S3BucketName: !GetAtt S3Stack.Outputs.S3BucketName
           S3BucketKMSAlias: !GetAtt S3Stack.Outputs.S3BucketKMSAlias
-          EKSName: !GetAtt BastionAndEksClusterStack.Outputs.EksClusterName
-          BastionAutoScalingGroup: !GetAtt BastionAndEksClusterStack.Outputs.BastionAutoScalingGroup
+          EKSName: !GetAtt EKSStack.Outputs.EksClusterName
+          BastionAutoScalingGroup: !GetAtt EKSStack.Outputs.BastionAutoScalingGroup
           VPCID: !GetAtt VPCStack.Outputs.VPCID
           NodeSecurityGroup: !Ref NodeSecurityGroup
           K8sNamespace: !Ref K8sNamespace
@@ -625,33 +625,33 @@ Outputs:
 
   # Bastion stack
   BastionSubstackName:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.SubstackName
+    Value: !GetAtt EKSStack.Outputs.SubstackName
   BastionSecurityGroup:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionSecurityGroup
+    Value: !GetAtt EKSStack.Outputs.BastionSecurityGroup
   BastionLaunchConfiguration:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionLaunchConfiguration
+    Value: !GetAtt EKSStack.Outputs.BastionLaunchConfiguration
   BastionAutoScalingGroup:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionAutoScalingGroup
+    Value: !GetAtt EKSStack.Outputs.BastionAutoScalingGroup
   BastionEIP:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionEIP
+    Value: !GetAtt EKSStack.Outputs.BastionEIP
   BastionInstanceProfile:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionInstanceProfile
+    Value: !GetAtt EKSStack.Outputs.BastionInstanceProfile
   BastionInstanceRole:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.BastionInstanceRole
+    Value: !GetAtt EKSStack.Outputs.BastionInstanceRole
   EC2LogGroup:
     Value: !Ref EC2LogGroup
 
   # EKS Cluster
   ControlPlaneSecurityGroup:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.ControlPlaneSecurityGroup
+    Value: !GetAtt EKSStack.Outputs.ControlPlaneSecurityGroup
   EksClusterName:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksClusterName
+    Value: !GetAtt EKSStack.Outputs.EksClusterName
   EksEndpoint:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksEndpoint
+    Value: !GetAtt EKSStack.Outputs.EksEndpoint
   EksCertAuthority:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksCertAuthority
+    Value: !GetAtt EKSStack.Outputs.EksCertAuthority
   EksServiceRoleArn:
-    Value: !GetAtt BastionAndEksClusterStack.Outputs.EksServiceRoleArn
+    Value: !GetAtt EKSStack.Outputs.EksServiceRoleArn
   NodeInstanceRoleArn:
     Value: !GetAtt NodeInstanceRole.Arn
   NodeSecurityGroupId:

--- a/templates/acs.yaml
+++ b/templates/acs.yaml
@@ -440,7 +440,6 @@ Resources:
       Role: !GetAtt HelmHelperLambdaRole.Arn
       Runtime: python2.7
       Timeout: 90
-      FunctionName: !Ref "AWS::StackName"
       Description: "A custom resource to manage Helm charts used for deploying ACS"
 
   HelmHelperLambdaCustomResource:

--- a/templates/bastion-and-eks-cluster.yaml
+++ b/templates/bastion-and-eks-cluster.yaml
@@ -962,7 +962,6 @@ Resources:
       Role: !GetAtt EksHelperLambdaRole.Arn
       Runtime: python2.7
       Timeout: 60
-      FunctionName: !Ref "AWS::StackName"
       Description: "A custom resource to manage EKS Cluster used for deploying ACS"    
 
   EksHelperLambdaCustomResource:

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -241,7 +241,6 @@ Resources:
     DependsOn:
       - EmptyBucketHandlerIamRole
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-ACS'
       Description: 'A custom lambda function to empty a given s3 buckets and delete it'
       Handler: org.alfresco.aws.lambda.handlers.cfn.EmptyS3Bucket
       Code:
@@ -256,8 +255,6 @@ Resources:
           Value: 'Alfresco Content Services'
         - Key: Stack
           Value: !Ref 'AWS::StackName'
-        - Key: Name
-          Value: !Sub '${AWS::StackName}-ACS'
 
   BucketCustomResource:
     Type: Custom::EmptyContentStoreBucket


### PR DESCRIPTION
Removed declaration of Lambda FunctionName as this causes issues with name length when adding another layering of CloudFormation nesting, plus, it's better to not provide names for resources anyway, unless absolutely necessary.

Also shortened the EKS stack name to be consistent with other stack names and to reduce the name length when another layer of CloudFormation nesting is added.