### PR TITLE
REPO-3941: Update ACS EKS with EA3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0-EA2
+
+## Features
+* Includes the <a href='docs/transform-services.md'>Transform Service</a> that performs transformations for Alfresco Content Services remotely in scalable containers.
+
 # 1.0.0-EA
 
 ## Features

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
-Version: 1.0.0-EA
+Version: 1.0.0-EA2
 
 | Component    | Version | Location |
 | -------------| --------|----------|
-| Helm Chart   | 1.1.3   | https://github.com/Alfresco/acs-deployment |
-| ACS AWS Image| 6.0.0.3 | https://hub.docker.com/r/alfresco/alfresco-content-repository-aws |
+| Helm Chart   | 1.1.5   | https://github.com/Alfresco/acs-deployment |
+| ACS AWS Image| 6.1.0-EA3 | https://hub.docker.com/r/alfresco/alfresco-content-repository-aws |

--- a/docs/cfn-releases.md
+++ b/docs/cfn-releases.md
@@ -2,7 +2,7 @@
 
 |CFN Template|Helm Chart|ACS AWS Image|
 |:---:|:---:|:---:|
-|1.0.0-EA|1.1.3|6.0.0.3|
+|1.0.0-EA2|1.1.5|6.1.0-EA3|
 
 ## Release process
 


### PR DESCRIPTION
   Increment VERSION to 1.0.0-EA2
   Update CHANGELOG and cfn-releases with 1.0.2-EA2