### PR TITLE
REPO-3987 - Parameterise number of repo pods running in ACS cluster

### DIFF
--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -174,7 +174,6 @@ EOF
       --set externalHost="$EXTERNAL_NAME" \
       --set externalPort="443" \
       --set repository.adminPassword="$ALFRESCO_PASSWORD" \
-      --set repository.replicaCount="$REPO_PODS" \
       --set alfresco-infrastructure.persistence.efs.enabled=true \
       --set alfresco-infrastructure.persistence.efs.dns="$EFS_NAME" \
       --set alfresco-search.resources.requests.memory="2500Mi",alfresco-search.resources.limits.memory="2500Mi" \

--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -81,6 +81,10 @@ else
               REGISTRYCREDENTIALS="$2";
               shift 2
               ;;
+          --repo-pods)
+              REPO_PODS="$2";
+              shift 2
+              ;;
           --install)
               INSTALL="true";
               shift
@@ -158,7 +162,7 @@ EOF
       --set repository.image.repository="alfresco/alfresco-content-repository-aws" \
       --set repository.image.tag="6.1.0-EA3" \
       --set registryPullSecrets=quay-registry-secret \
-      --set repository.replicaCount=2 \
+      --set repository.replicaCount="$REPO_PODS" \
       --namespace=$DESIREDNAMESPACE
   fi
   
@@ -170,6 +174,7 @@ EOF
       --set externalHost="$EXTERNAL_NAME" \
       --set externalPort="443" \
       --set repository.adminPassword="$ALFRESCO_PASSWORD" \
+      --set repository.replicaCount="$REPO_PODS" \
       --set alfresco-infrastructure.persistence.efs.enabled=true \
       --set alfresco-infrastructure.persistence.efs.dns="$EFS_NAME" \
       --set alfresco-search.resources.requests.memory="2500Mi",alfresco-search.resources.limits.memory="2500Mi" \

--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -27,7 +27,7 @@ usage() {
   echo -e "--upgrade \t Upgrade an existing ACS Helm Chart"
 }
 
-if [ $# -lt 11 ]; then
+if [ $# -lt 12 ]; then
   usage
 else
   # extract options and their arguments into variables.

--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -620,6 +620,7 @@ Resources:
           RegistryCredentials: !Ref RegistryCredentials
           IngressReleaseName: !Ref IngressReleaseName
           AcsReleaseName: !Ref AcsReleaseName
+          RepoPods: !Ref RepoPods
           Route53DnsZone: !Ref Route53DnsZone
 
 Outputs:

--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -64,6 +64,7 @@ Metadata:
             - AcsReleaseName
             - AlfrescoPassword
             - RegistryCredentials
+            - RepoPods
             - Route53DnsZone
 
       ParameterLabels:
@@ -137,6 +138,8 @@ Metadata:
           default: The helm chart release name of nginx-ingress
         AcsReleaseName:
           default: The helm chart release name of alfresco content services
+        RepoPods:
+          default: The number of repository pods in the cluster
         Route53DnsZone:
           default: The hosted zone to create Route53 Record for ACS
         UseCrossRegionReplication:
@@ -374,6 +377,10 @@ Parameters:
       Description: The private registry credentials in base64 format.
       NoEcho: True
       Default: ""
+    RepoPods:
+      Type: String
+      Description: The number of repository pods in the cluster
+      Default: "2"
     Route53DnsZone:
       AllowedPattern: ".+"
       ConstraintDescription: The hosted zone to create Route53 Record for ACS can not be empty

--- a/templates/acs.yaml
+++ b/templates/acs.yaml
@@ -274,7 +274,6 @@ Resources:
                   \ --alfresco-password ${AlfrescoPassword}\
                   \ --database-password ${DatabasePassword}\
                   \ --external-name ${AcsExternalName}\
-                  \ --repo-pods ${RepoPods}\
                   \ --upgrade"
               timeoutSeconds: 60
       DocumentType: Command

--- a/templates/acs.yaml
+++ b/templates/acs.yaml
@@ -33,6 +33,7 @@ Metadata:
             - RDSEndpoint
             - DatabasePassword
             - RegistryCredentials
+            - RepoPods
             - Route53DnsZone
 
       ParameterLabels:
@@ -76,6 +77,8 @@ Metadata:
           default: The helm chart release name of nginx-ingress
         AcsReleaseName:
           default: The helm chart release name of alfresco content services
+        RepoPods:
+          default: The number of repository pods in the cluster
         Route53DnsZone:
           default: The hosted zone to create Route53 Record for ACS
           
@@ -147,6 +150,9 @@ Parameters:
     AcsReleaseName:
       Type: String
       Description: The helm chart release name of alfresco content services
+    RepoPods:
+      Type: String
+      Description: The number of repository pods in the cluster
     Route53DnsZone:
       Type: String
       Description: The hosted zone to create Route53 Record for ACS
@@ -238,6 +244,7 @@ Resources:
                     - !Sub "--rds-endpoint ${RDSEndpoint}"
                     - !Sub "--database-password ${DatabasePassword}"
                     - !Sub "--external-name ${AcsExternalName}"
+                    - !Sub "--repo-pods ${RepoPods}"
                     - !Sub "--s3bucket-name ${S3BucketName}"
                     - !Sub "--s3bucket-kms-alias ${S3BucketKMSAlias}"
                     - !Sub "--s3bucket-location ${AWS::Region}"
@@ -267,6 +274,7 @@ Resources:
                   \ --alfresco-password ${AlfrescoPassword}\
                   \ --database-password ${DatabasePassword}\
                   \ --external-name ${AcsExternalName}\
+                  \ --repo-pods ${RepoPods}\
                   \ --upgrade"
               timeoutSeconds: 60
       DocumentType: Command


### PR DESCRIPTION
The number of repo pods running in the cluster is now parameterised with `2` pods as default.