### PR TITLE
Remove the describe-stacks command

### DIFF
--- a/createStack.sh
+++ b/createStack.sh
@@ -74,6 +74,4 @@ else
   # Wait until stack complete
   aws cloudformation wait stack-create-complete --stack-name $STACK_NAME
 
-  # Show stack
-  aws cloudformation describe-stacks --stack-name $STACK_NAME
 fi


### PR DESCRIPTION
Remove the describe-stacks command from the createStack.sh so that if the wait stack-create-complete can return 1 for letting the bamboo task fail.