### PR TITLE
Create RDS snapshot when deleting stack wasn't set

### DIFF
--- a/templates/acs-master-parameters.json
+++ b/templates/acs-master-parameters.json
@@ -64,6 +64,10 @@
     "ParameterValue": "@@AlfrescoPasswordValue@@"
   },
   {
+    "ParameterKey": "RDSCreateSnapshotWhenDeleted",
+    "ParameterValue": "@@RDSCreateSnapshotWhenDeletedValue@@"
+  },
+  {
     "ParameterKey": "RegistryCredentials",
     "ParameterValue": "@@RegistryCredentialsValue@@"
   },


### PR DESCRIPTION
For our dev environment we need the snapshot not created when we delete the stack. Otherwise we  hit the limit from 100 snapshots and can't deploy at anymore.