### PR TITLE
REPO-4052: Parameterise Alfresco Repository & Share docker images

### DIFF
--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -193,8 +193,8 @@ repository:
     initialDelaySeconds: 420
   adminPassword: \"$ALFRESCO_PASSWORD\"
   image:
-    repository: \"$REPO_IMAGE\"
-    tag: \"$REPO_TAG\"
+    `if [ ! -z ${REPO_IMAGE} ]; then echo repository: "$REPO_IMAGE"; fi`
+    `if [ ! -z ${REPO_TAG} ]; then echo tag: "$REPO_TAG"; fi`
   replicaCount: $REPO_PODS
   environment:
     JAVA_OPTS: \" -Dopencmis.server.override=true -Dopencmis.server.value=https://$EXTERNAL_NAME -Dalfresco.restApi.basicAuthScheme=true -Dsolr.base.url=/solr -Dsolr.secureComms=none -Dindex.subsystem.name=solr6 -Dalfresco.cluster.enabled=true -Ddeployment.method=HELM_CHART -Dlocal.transform.service.enabled=true -Dtransform.service.enabled=true -Dmessaging.broker.url='failover:($MQ_ENDPOINT)?timeout=3000&jms.useCompression=true' -Dmessaging.broker.user=$MQ_USERNAME -Dmessaging.broker.password=$MQ_PASSWORD -Xms2000M -Xmx2000M\"
@@ -272,8 +272,8 @@ share:
   livenessProbe:
     initialDelaySeconds: 420
   image:
-    repository: \"$SHARE_IMAGE\"
-    tag: \"$SHARE_TAG\"
+    `if [ ! -z ${SHARE_IMAGE} ]; then echo repository: "$SHARE_IMAGE"; fi`
+    `if [ ! -z ${SHARE_TAG} ]; then echo tag: "$SHARE_TAG"; fi`
 registryPullSecrets: quay-registry-secret" > $VALUES_FILE
 
   CHART_VERSION=1.1.10

--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -97,8 +97,24 @@ else
               REGISTRYCREDENTIALS="$2";
               shift 2
               ;;
+          --repo-image)
+              REPO_IMAGE="$2";
+              shift 2
+              ;;
+          --repo-tag)
+              REPO_TAG="$2";
+              shift 2
+              ;;
           --repo-pods)
               REPO_PODS="$2";
+              shift 2
+              ;;
+          --share-image)
+              SHARE_IMAGE="$2";
+              shift 2
+              ;;
+          --share-tag)
+              SHARE_TAG="$2";
               shift 2
               ;;
           --install)
@@ -177,7 +193,8 @@ repository:
     initialDelaySeconds: 420
   adminPassword: \"$ALFRESCO_PASSWORD\"
   image:
-    repository: \"alfresco/alfresco-content-repository-aws\"
+    repository: \"$REPO_IMAGE\"
+    tag: \"$REPO_TAG\"
   replicaCount: $REPO_PODS
   environment:
     JAVA_OPTS: \" -Dopencmis.server.override=true -Dopencmis.server.value=https://$EXTERNAL_NAME -Dalfresco.restApi.basicAuthScheme=true -Dsolr.base.url=/solr -Dsolr.secureComms=none -Dindex.subsystem.name=solr6 -Dalfresco.cluster.enabled=true -Ddeployment.method=HELM_CHART -Dlocal.transform.service.enabled=true -Dtransform.service.enabled=true -Dmessaging.broker.url='failover:($MQ_ENDPOINT)?timeout=3000&jms.useCompression=true' -Dmessaging.broker.user=$MQ_USERNAME -Dmessaging.broker.password=$MQ_PASSWORD -Xms2000M -Xmx2000M\"
@@ -254,6 +271,9 @@ messageBroker:
 share:
   livenessProbe:
     initialDelaySeconds: 420
+  image:
+    repository: \"$SHARE_IMAGE\"
+    tag: \"$SHARE_TAG\"
 registryPullSecrets: quay-registry-secret" > $VALUES_FILE
 
   CHART_VERSION=1.1.10

--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -453,11 +453,11 @@ Parameters:
     RepoImage:
       Type: String
       Description: The Alfresco Repository docker image name
-      Default: "alfresco/alfresco-content-repository-aws"
+      Default: ""
     RepoTag:
       Type: String
       Description: The Alfresco Repository docker tag name
-      Default: "6.1.0-RC7"
+      Default: ""
     RepoPods:
       Type: String
       Description: The number of repository pods in the cluster
@@ -465,11 +465,11 @@ Parameters:
     ShareImage:
       Type: String
       Description: The Alfresco Share docker image name
-      Default: "alfresco/alfresco-share"
+      Default: ""
     ShareTag:
       Type: String
       Description: The Alfresco Share docker tag name
-      Default: "6.1.0-RC3"
+      Default: ""
     Route53DnsZone:
       AllowedPattern: ".+"
       ConstraintDescription: The hosted zone to create Route53 Record for ACS can not be empty

--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -74,7 +74,11 @@ Metadata:
             - AcsReleaseName
             - AlfrescoPassword
             - RegistryCredentials
+            - RepoImage
+            - RepoTag
             - RepoPods
+            - ShareImage
+            - ShareTag
             - Route53DnsZone
 
       ParameterLabels:
@@ -158,8 +162,16 @@ Metadata:
           default: The helm chart release name of alfresco content services
         FluentdReleaseName:
           default: The helm chart release name of Fluentd
+        RepoImage:
+          default: The Alfresco Repository docker image name
+        RepoTag:
+          default: The Alfresco Repository docker tag name
         RepoPods:
           default: The number of repository pods in the cluster
+        ShareImage:
+          default: The Alfresco Share docker image name
+        ShareTag:
+          default: The Alfresco Share docker tag name
         Route53DnsZone:
           default: The hosted zone to create Route53 Record for ACS (including the . (dot) at the end)
         UseCrossRegionReplication:
@@ -438,10 +450,26 @@ Parameters:
       Description: The private registry credentials in base64 format.
       NoEcho: True
       Default: ""
+    RepoImage:
+      Type: String
+      Description: The Alfresco Repository docker image name
+      Default: "alfresco/alfresco-content-repository-aws"
+    RepoTag:
+      Type: String
+      Description: The Alfresco Repository docker tag name
+      Default: "6.1.0-RC7"
     RepoPods:
       Type: String
       Description: The number of repository pods in the cluster
       Default: "2"
+    ShareImage:
+      Type: String
+      Description: The Alfresco Share docker image name
+      Default: "alfresco/alfresco-share"
+    ShareTag:
+      Type: String
+      Description: The Alfresco Share docker tag name
+      Default: "6.1.0-RC3"
     Route53DnsZone:
       AllowedPattern: ".+"
       ConstraintDescription: The hosted zone to create Route53 Record for ACS can not be empty
@@ -802,7 +830,11 @@ Resources:
           RegistryCredentials: !Ref RegistryCredentials
           IngressReleaseName: !Ref IngressReleaseName
           AcsReleaseName: !Ref AcsReleaseName
+          RepoImage: !Ref RepoImage
+          RepoTag: !Ref RepoTag
           RepoPods: !Ref RepoPods
+          ShareImage: !Ref ShareImage
+          ShareTag: !Ref ShareTag
           Route53DnsZone: !Ref Route53DnsZone
 
 Outputs:

--- a/templates/acs.yaml
+++ b/templates/acs.yaml
@@ -36,7 +36,11 @@ Metadata:
             - MQUsername
             - MQPassword
             - RegistryCredentials
+            - RepoImage
+            - RepoTag
             - RepoPods
+            - ShareImage
+            - ShareTag
             - Route53DnsZone
 
       ParameterLabels:
@@ -86,8 +90,16 @@ Metadata:
           default: The helm chart release name of nginx-ingress
         AcsReleaseName:
           default: The helm chart release name of alfresco content services
+        RepoImage:
+          default: The Alfresco Repository docker image name
+        RepoTag:
+          default: The Alfresco Repository docker tag name
         RepoPods:
           default: The number of repository pods in the cluster
+        ShareImage:
+          default: The Alfresco Share docker image name
+        ShareTag:
+          default: The Alfresco Share docker tag name
         Route53DnsZone:
           default: The hosted zone to create Route53 Record for ACS (including the . (dot) at the end)
 
@@ -173,9 +185,21 @@ Parameters:
     AcsReleaseName:
       Type: String
       Description: The helm chart release name of alfresco content services
+    RepoImage:
+      Type: String
+      Description: The Alfresco Repository docker image name
+    RepoTag:
+      Type: String
+      Description: The Alfresco Repository docker tag name
     RepoPods:
       Type: String
       Description: The number of repository pods in the cluster
+    ShareImage:
+      Type: String
+      Description: The Alfresco Share docker image name
+    ShareTag:
+      Type: String
+      Description: The Alfresco Share docker tag name
     Route53DnsZone:
       Type: String
       Description: The hosted zone to create Route53 Record for ACS (including the . (dot) at the end)
@@ -254,7 +278,11 @@ Resources:
                     - !Sub "--mq-username ${MQUsername}"
                     - !Sub "--mq-password ${MQPassword}"
                     - !Sub "--external-name ${AcsExternalName}"
+                    - !Sub "--repo-image ${RepoImage}"
+                    - !Sub "--repo-tag ${RepoTag}"
                     - !Sub "--repo-pods ${RepoPods}"
+                    - !Sub "--share-image ${ShareImage}"
+                    - !Sub "--share-tag ${ShareTag}"
                     - !Sub "--s3bucket-name ${S3BucketName}"
                     - !Sub "--s3bucket-kms-alias ${S3BucketKMSAlias}"
                     - !Sub "--s3bucket-location ${AWS::Region}"
@@ -290,7 +318,11 @@ Resources:
                     - !Sub "--mq-username ${MQUsername}"
                     - !Sub "--mq-password ${MQPassword}"
                     - !Sub "--external-name ${AcsExternalName}"
+                    - !Sub "--repo-image ${RepoImage}"
+                    - !Sub "--repo-tag ${RepoTag}"
                     - !Sub "--repo-pods ${RepoPods}"
+                    - !Sub "--share-image ${ShareImage}"
+                    - !Sub "--share-tag ${ShareTag}"
                     - !Sub "--s3bucket-name ${S3BucketName}"
                     - !Sub "--s3bucket-kms-alias ${S3BucketKMSAlias}"
                     - !Sub "--s3bucket-location ${AWS::Region}"


### PR DESCRIPTION
- Parameterise Repository & Share image & tag name in cloudformation templates and set empty default.
- Adjust `scripts/helmAcs.sh` to set Image & Tag name(s) only if user provides them in the CFN template parameters.