### PR TITLE
REPO-4272 : ACS Deployment on AWS is broken due to EKS Worker nodes issues in CFN template

### DIFF
--- a/scripts/hardening_bootstrap.sh
+++ b/scripts/hardening_bootstrap.sh
@@ -648,7 +648,7 @@ function harden_workernode_kubernetes() {
 EOF
   service auditd restart
 
-  DOCKERD_CIS_OPTIONS="--icc=false --log-level=info --iptables=true --live-restore --userland-proxy=false"
+  DOCKERD_CIS_OPTIONS="--icc=false --log-level=info --iptables=true --userland-proxy=false"
   sed -i s#ExecStart=/usr/bin/dockerd#ExecStart=/usr/bin/dockerd\ "$DOCKERD_CIS_OPTIONS"#g /usr/lib/systemd/system/docker.service
   systemctl daemon-reload
   systemctl restart docker.service

--- a/templates/bastion-and-eks-cluster.yaml
+++ b/templates/bastion-and-eks-cluster.yaml
@@ -232,26 +232,24 @@ Mappings:
       AmiId: ami-02fd0b06f06d93dfc
   # see https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html for latest worker node AMI IDs
   NodeAmiRegionMap:
-    us-east-1:
-      AmiId: ami-0c24db5df6badc35a
     us-west-2:
-      AmiId: ami-0a2abab4107669c1b
+      AmiId: ami-0c28139856aaf9c3b
+    us-east-1:
+      AmiId: ami-0eeeef929db40543c
     us-east-2:
-      AmiId: ami-0c2e8d28b1f854c68
+      AmiId: ami-0484545fe7d3da96f
     eu-central-1:
-      AmiId: ami-010caa98bae9a09e2
-    eu-north-1:
-      AmiId: ami-06ee67302ab7cf838
+      AmiId: ami-032ed5525d4df2de3
     eu-west-1:
-      AmiId: ami-01e08d22b9439c15a
+      AmiId: ami-098fb7e9b507904e7
     ap-northeast-1:
-      AmiId: ami-0f0e8066383e7a2cb
+      AmiId: ami-07fdc9272ce5b0ce5
     ap-northeast-2:
-      AmiId: ami-0b7baa90de70f683f
+      AmiId: ami-091e0e1906e653417
     ap-southeast-1:
-      AmiId: ami-019966ed970c18502
+      AmiId: ami-038d55c26bf01998f
     ap-southeast-2:
-      AmiId: ami-06ade0abbd8eca425
+      AmiId: ami-0e07b5081bb77d540
 
 Conditions:
   isNodesMetricsEnabled: !Equals [!Ref NodesMetricsEnabled, "true"]
@@ -943,11 +941,6 @@ Resources:
           buckets: !Ref TemplateBucketName
       AWS::CloudFormation::Init:
         config:
-          packages:
-            yum:
-              awslogs: []
-              amazon-ssm-agent: []
-              amazon-efs-utils: []
           files:
             '/etc/awslogs/awscli.conf':
               content: !Sub |
@@ -1092,6 +1085,9 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
             #!/bin/bash -xe
+            pip uninstall urllib3 -y
+            yum install -y awslogs
+            yum install -y amazon-ssm-agent
             yum install -y amazon-efs-utils
             /etc/eks/bootstrap.sh ${EKSClusterName}
             /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource NodeLaunchConfig --region ${AWS::Region}

--- a/templates/bastion-and-eks-cluster.yaml
+++ b/templates/bastion-and-eks-cluster.yaml
@@ -218,8 +218,6 @@ Mappings:
       AmiId: ami-0cd3dfa4e37921605
     eu-central-1:
       AmiId: ami-0cfbf4f6db41068ac
-    eu-north-1:
-      AmiId: ami-86fe70f8
     eu-west-1:
       AmiId: ami-08935252a36e25f85
     ap-northeast-1:


### PR DESCRIPTION
- Update all EKS Worker node ami's in the cloudformation template
- Apply a hot-fix for yum package installations to be via EC2 `UserData` instead of `config` for installing packages