### PR TITLE
REPO-4272: Use a default ACS Repository Image for AWS

### DIFF
--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -196,8 +196,8 @@ repository:
   livenessProbe:
     initialDelaySeconds: 420
   adminPassword: \"$ALFRESCO_PASSWORD\"
-  `if [ ! -z ${REPO_IMAGE} ] || [ ! -z ${REPO_TAG} ]; then echo image: ; else echo -e 'image: \n    repository: "alfresco/alfresco-content-repository-aws"' ; fi`
-    `if [ ! -z ${REPO_IMAGE} ]; then echo repository: "$REPO_IMAGE"; fi`
+  image:
+    repository: "$REPO_IMAGE"
     `if [ ! -z ${REPO_TAG} ]; then echo tag: "$REPO_TAG"; fi`
   replicaCount: $REPO_PODS
   environment:

--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -196,7 +196,7 @@ repository:
   livenessProbe:
     initialDelaySeconds: 420
   adminPassword: \"$ALFRESCO_PASSWORD\"
-  `if [ ! -z ${REPO_IMAGE} ] || [ ! -z ${REPO_TAG} ]; then echo image: ; else echo -e 'image: \n    repository: \\"alfresco/alfresco-content-repository-aws\\"' ; fi`
+  `if [ ! -z ${REPO_IMAGE} ] || [ ! -z ${REPO_TAG} ]; then echo image: ; else echo -e 'image: \n    repository: "alfresco/alfresco-content-repository-aws"' ; fi`
     `if [ ! -z ${REPO_IMAGE} ]; then echo repository: "$REPO_IMAGE"; fi`
     `if [ ! -z ${REPO_TAG} ]; then echo tag: "$REPO_TAG"; fi`
   replicaCount: $REPO_PODS

--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -196,7 +196,7 @@ repository:
   livenessProbe:
     initialDelaySeconds: 420
   adminPassword: \"$ALFRESCO_PASSWORD\"
-  `if [ ! -z ${REPO_IMAGE} ] || [ ! -z ${REPO_TAG} ]; then echo image: ; fi`
+  `if [ ! -z ${REPO_IMAGE} ] || [ ! -z ${REPO_TAG} ]; then echo image: ; else echo -e 'image: \n    repository: \\"alfresco/alfresco-content-repository-aws\\"' ; fi`
     `if [ ! -z ${REPO_IMAGE} ]; then echo repository: "$REPO_IMAGE"; fi`
     `if [ ! -z ${REPO_TAG} ]; then echo tag: "$REPO_TAG"; fi`
   replicaCount: $REPO_PODS

--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -453,7 +453,7 @@ Parameters:
     RepoImage:
       Type: String
       Description: The Alfresco Repository docker image name
-      Default: ""
+      Default: "alfresco/alfresco-content-repository-aws"
     RepoTag:
       Type: String
       Description: The Alfresco Repository docker tag name


### PR DESCRIPTION
- Use `alfresco/alfresco-content-repository-aws` as default ACS Repository Docker Image