### PR TITLE
APPSREPO-673 : Sync service included into ACS part II - ACS AWS Deplo…

### DIFF
--- a/scripts/helmAcs.sh
+++ b/scripts/helmAcs.sh
@@ -200,7 +200,7 @@ repository:
   adminPassword: \"$ALFRESCO_PASSWORD\"
   image:
     repository: quay.io/alfresco/alfresco-content-repository-aws
-    tag: \"6.1.1-RC1\"
+    tag: \"feature-6.1.N-APPSREPO-673_include_sync_aws-6.1.1-SNAPSHOT\"
   replicaCount: $REPO_PODS
   environment:
     JAVA_OPTS: \" -Dopencmis.server.override=true -Dopencmis.server.value=https://$EXTERNAL_NAME -Dalfresco.restApi.basicAuthScheme=true -Dsolr.base.url=/solr -Dsolr.secureComms=none -Dindex.subsystem.name=solr6 -Dalfresco.cluster.enabled=true -Ddeployment.method=HELM_CHART -Dlocal.transform.service.enabled=false -Dtransform.service.enabled=true -Dmessaging.broker.url='failover:($MQ_ENDPOINT)?timeout=3000&jms.useCompression=true' -Dmessaging.broker.user=$MQ_USERNAME -Dmessaging.broker.password=$MQ_PASSWORD -Xms2000M -Xmx2000M\"    

--- a/templates/acs-deployment-master.yaml
+++ b/templates/acs-deployment-master.yaml
@@ -420,7 +420,7 @@ Parameters:
       ConstraintDescription: The NGINX Ingress version can not be empty
       Type: String
       Description: The nginx-ingress chart version
-      Default: "0.14.0"
+      Default: "0.21.0"
     IngressReleaseName:
       AllowedPattern: ".+"
       ConstraintDescription: The helm chart release name of nginx-ingress can not be empty


### PR DESCRIPTION
…yment with EKS, AmazonMQ and Aurora

   - ACS chart version 2.1.0 which includes Sync service
   - use ACS image 6.1.1-RC1
   - configure the Sync chart to use the same AmazonMQ and AuroraMysql as ACS
   - upgraded to nginx 0.21.0 from 0.14.0, same as 'https://git.alfresco.com/Repository/acs-k8s-cluster/blob/master/scripts/deploy_acs_cluster.sh'
   - disable the nginx ingress provided by the alfresco-infrastructure as we install it separately beforehand
   - override the alfresco-sync-service.messaging.broker.endpoint with $MQ_ENDPOINT instead of providing separately the host, protocol and port
   - overwrite the messaging.broker.endpoint property via the EXTRA_JAVA_OPTS property